### PR TITLE
카카오 로그인 실서버 연동 구현

### DIFF
--- a/mock.json
+++ b/mock.json
@@ -1,0 +1,7 @@
+{
+    "login": {
+      "authorization": "Bearer MOCK_ACCESS_TOKEN",
+      "refreshToken": "MOCK_REFRESH_TOKEN"
+    }
+  }
+  

--- a/src/components/KakaoLoginButton.js
+++ b/src/components/KakaoLoginButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const KAKAO_REST_API_KEY = '90667b555f7cee12aa381be1d24a87e5';
-const REDIRECT_URI = 'http://localhost:5173/oauth/callback/kakao';
+const REDIRECT_URI = 'http://localhost:3000/oauth/callback/kakao';
 
 const KakaoLoginButton = () => {
   const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;

--- a/src/pages/KakaoCallback.js
+++ b/src/pages/KakaoCallback.js
@@ -6,42 +6,28 @@ const KakaoCallback = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const code = new URL(window.location.href).searchParams.get('code');
-    const redirectUri = 'http://localhost:5173/oauth/callback/kakao';
+    console.log('[🧪 MOCK 테스트 시작] axios 요청 중...');
 
-    console.log('[🔍 디버깅] 현재 URL:', window.location.href);
-    console.log('[🔍 디버깅] 추출된 code:', code);
-    console.log('[🔍 디버깅] redirectUri:', redirectUri);
-
-    if (code) {
-      console.log('[🚀 요청 시작] 백엔드로 POST 전송 준비 중...');
-      axios.post('https://likelion-yonsei.shop/login', {
-        code: code,
-        redirectUri: redirectUri
-      })
+    // ✅ 조건문 없이 무조건 실행
+    axios.get('http://localhost:4001/login')
       .then((res) => {
-        console.log('[✅ 응답 수신] 전체 응답:', res);
-        const accessToken = res.headers['authorization'];
-        const refreshToken = res.headers['refreshtoken'];
+        console.log('[✅ MOCK 응답 수신]', res.data);
 
-        console.log('[📦 저장] AccessToken:', accessToken);
-        console.log('[📦 저장] RefreshToken:', refreshToken);
+        const accessToken = res.data.authorization;
+        const refreshToken = res.data.refreshToken;
 
         localStorage.setItem('accessToken', accessToken);
         localStorage.setItem('refreshToken', refreshToken);
 
-        console.log('[➡️ 이동] 홈(/)으로 라우팅 중...');
-        navigate('/');
+        console.log('[📦 저장 완료] accessToken:', accessToken);
+        navigate('/home');
       })
       .catch((err) => {
-        console.error('[❌ 에러 발생] 로그인 실패:', err);
+        console.error('[❌ MOCK 요청 실패]', err);
       });
-    } else {
-      console.warn('[⚠️ 경고] URL에 code 파라미터가 없습니다.');
-    }
   }, [navigate]);
 
-  return <div>로그인 중입니다...</div>;
+  return <div>로그인 중입니다... (mock)</div>;
 };
 
 export default KakaoCallback;

--- a/src/pages/KakaoCallback.js
+++ b/src/pages/KakaoCallback.js
@@ -6,15 +6,24 @@ const KakaoCallback = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    console.log('[🧪 MOCK 테스트 시작] axios 요청 중...');
+    const code = new URLSearchParams(window.location.search).get('code');
+    const redirectUri = 'http://localhost:3000/oauth/callback/kakao';
 
-    // ✅ 조건문 없이 무조건 실행
-    axios.get('http://localhost:4001/login')
+    console.log('[🔍 디버깅] 현재 URL:', window.location.href);
+    console.log('[🔍 디버깅] 추출된 code:', code);
+    console.log('[🔍 디버깅] redirectUri:', redirectUri);
+
+    if (code) {
+      console.log('[🚀 요청 시작] 백엔드로 POST 요청 중...');
+      axios.post('https://likelion-yonsei.shop/login', {
+        code,
+        redirectUri,
+      })
       .then((res) => {
-        console.log('[✅ MOCK 응답 수신]', res.data);
+        console.log('[✅ 응답 수신]', res);
 
-        const accessToken = res.data.authorization;
-        const refreshToken = res.data.refreshToken;
+        const accessToken = res.headers['authorization'];
+        const refreshToken = res.headers['refreshtoken'];
 
         localStorage.setItem('accessToken', accessToken);
         localStorage.setItem('refreshToken', refreshToken);
@@ -23,11 +32,14 @@ const KakaoCallback = () => {
         navigate('/home');
       })
       .catch((err) => {
-        console.error('[❌ MOCK 요청 실패]', err);
+        console.error('[❌ 요청 실패]', err);
       });
+    } else {
+      console.warn('[⚠️ 경고] URL에 code 파라미터가 없습니다.');
+    }
   }, [navigate]);
 
-  return <div>로그인 중입니다... (mock)</div>;
+  return <div>로그인 중입니다... (실제 백엔드)</div>;
 };
 
 export default KakaoCallback;


### PR DESCRIPTION
- 카카오 인가 코드를 백엔드에 axios.post로 전달하여 실서버 연동 테스트
- 응답으로 받은 accessToken, refreshToken을 localStorage에 저장
- 저장 후 /home 페이지로 navigate
- 디버깅 로그 및 에러 처리 포함
- redirectUri는 http://localhost:3000/oauth/callback/kakao 기준